### PR TITLE
Updating Travis for new container-based infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: true
 language: bash
 install:
   - ./install.sh


### PR DESCRIPTION
hey bro, I don't know why, but, my Travis updated, and now, they started using a new container-based structure,

[Using container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/)

and we need to update this file to use `sudo`, like they are saying in the article, because this is breaking the build!

check below:

https://travis-ci.org/oieduardorabelo/dotfiles

![Carlos](https://dl.dropboxusercontent.com/s/z8xumfpodb1s38m/Screen_Shot_2015-04-03_at_10_13_35_PM.png)

![Eduardo](https://dl.dropboxusercontent.com/s/85pkyp9zuyyt45i/Screen_Shot_2015-04-03_at_10_13_27_PM.png)
