### PR TITLE
Updated to shellcheck 0.3.7-5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 main() {
-  local filename="shellcheck_0.3.7-1_amd64.deb"
+  local filename="shellcheck_0.3.7-5_amd64.deb"
   wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/$filename"
   sudo dpkg -i "$filename"
 }


### PR DESCRIPTION
Previous version is no longer available.
