### PR TITLE
Remove sudo requirement

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,8 +1,0 @@
-language: ruby
-install:
-  - ./install.sh
-script:
-  - ./build.sh
-notifications:
-  email: false
-sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: bash
+sudo: false
+os:
+  - linux
+  - osx
+addons:
+  apt:
+    packages:
+    - shellcheck
 install:
   - ./install.sh
 script:
@@ -6,7 +14,3 @@ script:
   - ./tests/test-custom-check.sh
 notifications:
   email: false
-sudo: required
-os:
-  - linux
-  - osx

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,7 @@
 set -eo pipefail
 
 linux() {
-  sudo curl -Lso \
-    /usr/bin/shellcheck \
-    https://github.com/caarlos0/shellcheck-docker/releases/download/v0.4.3/shellcheck
-  sudo chmod +x /usr/bin/shellcheck
+  hash shellcheck 2>/dev/null || { echo >&2 "I require shellcheck but it wasn’t installed. Aborting."; exit 1; }
 }
 
 osx() {

--- a/shippable.yml.example
+++ b/shippable.yml.example
@@ -1,8 +1,0 @@
-language: ruby
-install:
-  - ./build/install.sh
-script:
-  - ./build/build.sh
-notifications:
-  email: false
-sudo: required

--- a/travis.yml.example
+++ b/travis.yml.example
@@ -1,8 +1,12 @@
 language: bash
-sudo: required
+sudo: false
 os:
   - linux
   - osx
+addons:
+  apt:
+    packages:
+    - shellcheck
 install:
   - ./build/install.sh
 script:


### PR DESCRIPTION
- Allows us to use more modern Travi-CI infrastructure.
- Couldn’t find a way to fix this for Shippable so remove that config. I don’t need it specifically.
