### PR TITLE
Add support for executable files without a `.sh` extension

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,9 +30,10 @@ find_prunes() {
 find_cmd() {
   # GNU `find` dropped compatibility support for the `+` syntax with 4.5.12 (release 2013), it
   # instead uses `/` which has been supported for a long time. BSD `find` however still used `+`.
-  local perm_format_specifier="+"
-  if (( $(find --version /dev/null 2>&1 | grep GNU > /dev/null 2>&1; echo $?) == 0 )); then
-    perm_format_specifier="/"
+  if [ "$(find --version > /dev/null 2>&1)" ]; then
+    local perm_format_specifier="/"
+  else
+    local perm_format_specifier="+"
   fi
 
   echo "find . -type f -and \( -perm ${perm_format_specifier}111 -or -name '*.sh' \) $(find_prunes)"

--- a/build.sh
+++ b/build.sh
@@ -30,9 +30,9 @@ find_prunes() {
 find_cmd() {
   # GNU `find` dropped compatibility support for the `+` syntax with 4.5.12 (release 2013), it
   # instead uses `/` which has been supported for a long time. BSD `find` however still used `+`.
-  local perm_format_specifier="/"
-  if [ "$(uname -s)" = "Darwin" ]; then
-    perm_format_specifier="+"
+  local perm_format_specifier="+"
+  if (( $(find --version /dev/null 2>&1 | grep GNU > /dev/null 2>&1; echo $?) == 0 )); then
+    perm_format_specifier="/"
   fi
 
   echo "find . -type f -and \( -perm ${perm_format_specifier}111 -or -name '*.sh' \) $(find_prunes)"

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ find_prunes() {
 }
 
 find_cmd() {
-  echo "find . -type f -and \( -perm +x -or -name '*.sh' \) $(find_prunes)"
+  echo "find . -type f -and \( -perm +111 -or -name '*.sh' \) $(find_prunes)"
 }
 
 check_all_executables() {

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,14 @@ find_prunes() {
 }
 
 find_cmd() {
-  echo "find . -type f -and \( -perm +111 -or -name '*.sh' \) $(find_prunes)"
+  # GNU `find` dropped compatibility support for the `+` syntax with 4.5.12 (release 2013), it
+  # instead uses `/` which has been supported for a long time. BSD `find` however still used `+`.
+  local perm_format_specifier="/"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    perm_format_specifier="+"
+  fi
+
+  echo "find . -type f -and \( -perm ${perm_format_specifier}111 -or -name '*.sh' \) $(find_prunes)"
 }
 
 check_all_executables() {

--- a/tests/test-custom-check.sh
+++ b/tests/test-custom-check.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 # Grant that custom checks are working.
 set -eo pipefail
+
 # shellcheck disable=SC1091
 source ./build.sh
+
+# Lint the build script
+echo "Linting the build.sh script..."
 check ./build.sh
+
+# Test that we find the correct amount of files.
+echo -e "\nValidating the result of find_cmd()..."
+files=$(eval "$(find_cmd)")
+files_count=$(echo "$files" | wc -l)
+
+expected_files_count=8
+if (( files_count == expected_files_count )); then
+  printf "\r\033[2K  [ \033[00;32mOK\033[0m ] Found the expected number of files (%s)\n" $expected_files_count
+else
+  printf "\r\033[2K  [\033[0;31mFAIL\033[0m] Build scripts’s find_cmd didn’t find the expected number of files (%s)\n" $expected_files_count
+  printf "\r\033[2K         Files found:\n"
+  for file in $files; do
+    printf "\r\033[2K         - %s\n" "$file"
+  done
+  exit 1
+fi
+
+exit 0

--- a/tests/test-custom-no-extension
+++ b/tests/test-custom-no-extension
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "hi"


### PR DESCRIPTION
As can be seen in the logs for 1473a6b (see build logs linked below), the current script doesn’t find the shell-script without the `.sh` extension. As can be seen in the following log after I added the file `tests/test-custom-no-extension` and set its file mode to `+x`:

```
Linting all executables and .sh files, ignoring files inside git modules...
[ OK ] Linting ./tests/ksh.sh...
[ OK ] Linting ./tests/sh.sh...
[ OK ] Linting ./tests/bash.sh...
[ OK ] Linting ./tests/test-custom-check.sh...
[ OK ] Linting ./build.sh...
[ OK ] Linting ./install.sh...
```

This is the same for both for the Linux and OS X builds:
- [Linux build log](https://travis-ci.org/rastersize/shell-ci-build/jobs/110600324#L155)
- [OS X build log](https://travis-ci.org/rastersize/shell-ci-build/jobs/110600325#L2441)

This PR resolves this issue by reverting PR #20’s change to the `find` command arguments and to use `+111` instead of `+x` for the `-perm` argument. Further it resolves compatibility with modern GNU `find` versions (4.5.12+, released in 2013) as it expects the value to be prepended by `/` instead.

I’ve also added a very rudimentary test that makes sure the built `find_cmd` fins the correct number of files.

@caarlos0 let me know if this looks good to you, or if there’s something you’d like me to modify.
